### PR TITLE
Ensure local file "urls" are handled properly.

### DIFF
--- a/src/Utils/UrlUtils.php
+++ b/src/Utils/UrlUtils.php
@@ -63,6 +63,16 @@ class UrlUtils
             $abs = $parts["scheme"].'://'.$abs;
         }
 
+        // Handle local files.
+        if ($parts["scheme"] == 'file') {
+            // Remove protocol for local files. And try to ensure the returned
+            // path is an absolute, system-specific file path.
+            $abs = str_replace('file://', '', $abs);
+            if (($abs_real = realpath($abs))) {
+                $abs = $abs_real;
+            }
+        }
+
         return $abs;
     }
 


### PR DESCRIPTION
# Issue

If I run the processing on the xsd files provided here https://www.vdv.de/ip-kom-oev.aspx (https://www.vdv.de/trias-xsd-v1.0.zipx?forced=true) I get following error:
Warning: DOMDocument::load(): I/O warning : failed to load external entity 
`"file:///W:/htdocs/customer/sites/all/modules/contrib/clients_vdv/file%253A/W%253A/htdocs/customer/sites/all/modules/contrib/clients_vdv/trias-xsd-v1.0/siri-1.4/siri_situationExchange_service.xsd" in W:\htdocs\customer\sites\all\modules\contrib\clients_vdv\vendor\goetas\xsd-reader\src\SchemaReader.php on line 758`
## System Info

PHP 5.5.10 64x VC11
Win 8
# Solution proposal

It seems like includes on local files aren't handled properly. I've added code to detect and handle local file includes in <code>UrlUtils::resolveRelativeUrl()</code>.
The code uses <code>realpath()</code> to convert the path into a system specific absolute path. But if <code>realpath()</code> doesn't find a file it rather returns the raw file path without the <code>file://</code> schema instead FALSE as returned by <code>realpath()</code>. I think this keeps the information level higher in case of an subsequent error.
