### PR TITLE
Typo in example, functionname is plural; getSchemas()

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ $schema = $reader->readFile("http://www.example.com/exaple.xsd");
 
 // Now you can navigate the entire schema structure
 
-foreach ($schema->getSchema() as $innerSchema){
+foreach ($schema->getSchemas() as $innerSchema){
 
 }
 foreach ($schema->getTypes() as $type){
@@ -67,5 +67,5 @@ foreach ($schema->getAttributeGroups() as $attrGroup){
 Note
 ----
 
-I'm sorry for the *terrible* english fluency used inside the documentation, I'm trying to improve it. 
+I'm sorry for the *terrible* english fluency used inside the documentation, I'm trying to improve it.
 Pull Requests are welcome.


### PR DESCRIPTION
Whilst trying out xsd-reader I found a typo in the example in the readme.