### PR TITLE
Filesystem paths should not be urlencoded

### DIFF
--- a/src/SchemaReader.php
+++ b/src/SchemaReader.php
@@ -633,7 +633,8 @@ class SchemaReader
 
     private function loadImport(Schema $schema, DOMElement $node)
     {
-        $file = UrlUtils::resolveRelativeUrl($node->ownerDocument->documentURI, $node->getAttribute("schemaLocation"));
+        $base = urldecode($node->ownerDocument->documentURI);
+        $file = UrlUtils::resolveRelativeUrl($base, $node->getAttribute("schemaLocation"));
         if ($node->hasAttribute("namespace")
             && isset(self::$globalSchemaInfo[$node->getAttribute("namespace")])
             && isset($this->loadedFiles[self::$globalSchemaInfo[$node->getAttribute("namespace")]])

--- a/tests/FilesystemTest.php
+++ b/tests/FilesystemTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Goetas\XML\XSDReader\Tests;
+
+class FilesystemTest extends BaseTest
+{
+
+    /**
+     * Test that a referenced Xsd file is found when the base-path contains " " (space-character).
+     *
+     * Covers the issue described in {@link https://github.com/goetas/xsd-reader/pull/10 PR #10}.
+     */
+    public function testReferencedOnFileSystem_1()
+    {
+        /*
+         * Using vfsStream seems ideal, but currently seems to have an issue with directorypaths with a space in
+         * combination with DOMDocument::load(). For now use actual filesystem to create the testcase.
+         */
+        $schemaXsd = __DIR__ . DIRECTORY_SEPARATOR . 'foo bar' . DIRECTORY_SEPARATOR . 'schema.xsd';
+
+        $schema = $this->reader->readFile($schemaXsd);
+
+        $this->assertCount(1, $schema->getTypes());
+        $this->assertInstanceOf('Goetas\XML\XSDReader\Schema\Type\ComplexType', $schema->findType('myType', 'http://www.example.com'));
+    }
+
+}

--- a/tests/UrlUtilsTest.php
+++ b/tests/UrlUtilsTest.php
@@ -63,6 +63,8 @@ class UrlUtilsTest extends BaseTest {
     {
         $this->assertEquals('file:///test', UrlUtils::resolveRelativeUrl('file:///', '/test'));
         $this->assertEquals('file:///test', UrlUtils::resolveRelativeUrl('file:///', 'test'));
+        /* Assert that any filenames will be stripped from base */
+        $this->assertEquals('file:///bar.xsd', UrlUtils::resolveRelativeUrl('file:///foo.xsd', 'bar.xsd'));
     }
 
 
@@ -79,4 +81,4 @@ class UrlUtilsTest extends BaseTest {
         $this->assertEquals('/testing', UrlUtils::resolveRelativeUrl('/test/child', '../testing'));
     }
 
-} 
+}

--- a/tests/foo bar/referenced.xsd
+++ b/tests/foo bar/referenced.xsd
@@ -1,0 +1,10 @@
+<xs:schema targetNamespace="http://www.example.com" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+	<xs:complexType name="myType"></xs:complexType>
+	<xs:element name="myElement" type="myType"></xs:element>
+
+	<xs:group name="myGroup">
+		<xs:sequence></xs:sequence>
+	</xs:group>
+	<xs:attribute name="myAttribute" type="xs:string"></xs:attribute>
+	<xs:attributeGroup name="myAttributeGroup"></xs:attributeGroup>
+</xs:schema>

--- a/tests/foo bar/schema.xsd
+++ b/tests/foo bar/schema.xsd
@@ -1,0 +1,3 @@
+<xs:schema targetNamespace="http://www.example.com" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+	<xs:include schemaLocation="referenced.xsd" />
+</xs:schema>

--- a/tests/fooz%20baz/referenced.xsd
+++ b/tests/fooz%20baz/referenced.xsd
@@ -1,0 +1,10 @@
+<xs:schema targetNamespace="http://www.example.com" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+	<xs:complexType name="myType"></xs:complexType>
+	<xs:element name="myElement" type="myType"></xs:element>
+
+	<xs:group name="myGroup">
+		<xs:sequence></xs:sequence>
+	</xs:group>
+	<xs:attribute name="myAttribute" type="xs:string"></xs:attribute>
+	<xs:attributeGroup name="myAttributeGroup"></xs:attributeGroup>
+</xs:schema>

--- a/tests/fooz%20baz/schema.xsd
+++ b/tests/fooz%20baz/schema.xsd
@@ -1,0 +1,3 @@
+<xs:schema targetNamespace="http://www.example.com" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+	<xs:include schemaLocation="referenced.xsd" />
+</xs:schema>


### PR DESCRIPTION
SchemaReader::loadImport() feeds UrlUtils::resolveRelativeUrl() with $node->ownerDocument->documentURI and $node->getAttribute("schemaLocation") to determine the location of the file. These values are urlencoded. That means for instance that spaces will be formatted as "%20". If an URI refers to a location on a filesystem, because the scheme of the URI is "file", or no scheme is given, then the path should be url decoded.

The tests have been updated in this commit with an assertion to cover that. Furtermore tested on both Windows 7 and Ubuntu 14.04 that "%20" in a path leads to failure of resolving it. Assuming a dir "./foo bar" exists, php -r "echo file_exists('foo%20bar')?'true':'false';echo PHP_EOL;" vs php -r "echo file_exists('foo bar')?'true':'false';echo PHP_EOL;".

This solves the same issue that PR #8 tries to solve, but does so as well when there is no scheme and saves using realpath (which does a resolve of the path as well).